### PR TITLE
gx update go-libp2p 6.0.12

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.12: QmcmV4wfniA3HJMpmfeMdnvSxADwN7XGpte1DFiQBi7GN2
+0.0.13: QmRJDDAuHz1NbjgSieikJuRDo3TkccSBwxueupn1KYpryo

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmUDzeFgYrRmHL2hUB6NZmqcBVQtUzETwmFRUc9onfSSHr",
+      "hash": "QmUEqyXr97aUbNmQADHYNknjwjjdVpJXEt1UZXmSG81EV4",
       "name": "go-libp2p",
-      "version": "6.0.8"
+      "version": "6.0.12"
     }
   ],
   "gxVersion": "0.10.0",
@@ -19,6 +19,6 @@
   "license": "MIT",
   "name": "go-libp2p-gostream",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.0.12"
+  "version": "0.0.13"
 }
 


### PR DESCRIPTION
License: MIT
Signed-off-by: Adrian Lanzafame <adrianlanzafame92@gmail.com>